### PR TITLE
Added ability to override timeouts if set in the options

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ grunt.initConfig({
       browsers: ['Chrome', 'Firefox'],
       reporter: 'Spec',
       baseUrl: 'https://develop.mywebsite.local',
-      args: '--ignore-certificate-errors'
+      args: '--ignore-certificate-errors',
+      timeout: 10000, // in milliseconds
+      suiteTimeout: 90000 // in milliseconds
     },
     files: ['test/*.js']
   },

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -12,7 +12,9 @@ var protractor = require('protractor'),
 
 module.exports = function (grunt, fileGroup, browser, options, next) {
   var capabilities,
-      driver;
+      driver,
+      timeout = options.timeout ? options.timeout : 10000,
+      suiteTimeout = options.suiteTimeout ? options.suiteTimeout : 90000;
 
   // if browser is a simple string, just use selenium
   if (typeof browser === 'string') {
@@ -63,7 +65,7 @@ module.exports = function (grunt, fileGroup, browser, options, next) {
     return next();
   }
 
-  driver.manage().timeouts().setScriptTimeout(10000);
+  driver.manage().timeouts().setScriptTimeout(timeout);
   driver.getSession().then(function(session) {
     var ptor = protractor.wrapDriver(
       driver,
@@ -89,7 +91,7 @@ module.exports = function (grunt, fileGroup, browser, options, next) {
     };
 
     var mocha = new Mocha(options);
-    mocha.suite.timeout(90000);
+    mocha.suite.timeout(suiteTimeout);
     mocha.suite.on('pre-require', function(context, file, m) {
       if (Module._cache[file]) {
         delete Module._cache[file];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-mocha-protractor",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Run e2e angular tests with webdriver.",
   "homepage": "https://github.com/noblesamurai/grunt-mocha-protractor",
   "bugs": "https://github.com/noblesamurai/grunt-mocha-protractor/issues",


### PR DESCRIPTION
I am leveraging grunt-mocha-protractor on a website.  Some of my api's take a long time and my tests fail periodically.  I thought it would be nice to have the ability to override the timeouts.  

Let me know if you would like me to change the implementation. 

All tests are passing and jshint passed as well.

Thanks!
